### PR TITLE
Fixed virtual environnment naming discrepancy, execution permission for bash script and cuda availability check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+./venv-pyannote-audio-elan
+*.log

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ git clone https://github.com/coxchristopher/pyannote-audio-elan
 cd pyannote-audio-elan
 
 python3.10 -m venv venv-pyannote-audio-elan
-source venv-pyannote-audio-elan
+source venv-pyannote-audio-elan/bin/activate
 pip install -r requirements.txt
+chmod +x pyannote-audio-elan.sh
 ```
 
 Once all of these tools and packages have been installed, pyannote-audio-elan can be made available to ELAN as follows:

--- a/pyannote-audio-elan.py
+++ b/pyannote-audio-elan.py
@@ -247,7 +247,7 @@ if torch.backends.mps.is_available() and torch.backends.mps.is_built():
     if 'apple m' in cpuinfo.get_cpu_info().get('brand_raw').lower():
         device = 'mps'
         pipeline.to(torch.device('mps'))
-elif torch.backends.cuda.is_available() and torch.backends.cuda.is_built():
+elif torch.cuda.is_available() and torch.backends.cuda.is_built():
     device = 'cuda'
     pipeline.to(torch.device('cuda'))
 

--- a/pyannote-audio-elan.sh
+++ b/pyannote-audio-elan.sh
@@ -14,7 +14,7 @@
 # ** Edit the following line to point to the directory in which 'ffmpeg' is
 # ** found on this computer.
 # **
-export FFMPEG_DIR="/Users/chris/Unix"
+export FFMPEG_DIR="/usr/bin/"
 
 export LC_ALL="en_US.UTF-8"
 export PYTHONIOENCODING="utf-8"
@@ -26,5 +26,5 @@ export PATH="$PATH:$FFMPEG_DIR"
 export PYTORCH_ENABLE_MPS_FALLBACK=1
 
 # Activate the virtual environment, then execute the main recognizer script.
-source ./venv-pyannote/bin/activate
-exec python3 ./pyannote-audio-elan.py $1
+source ./venv-pyannote-audio-elan/bin/activate
+exec python3 ./pyannote-audio-elan.py $1 >> ./elan_wrapper_debug.log 2>&1


### PR DESCRIPTION
Updated README.md: 
Fixed 'Permission denied' error when executing .sh script from Elan Recognizer.
Saving .log file of Python script execution.

Added .gitignore to avoid tracking virtual environment and log file.

Fixed "AttributeError: module 'torch.backends.cuda' has no attribute 'is_available')" in pyannote-audio-elan.py

Diarization is working on Elan, generating the corresponding tiers now, but the following message is still showing during the progress : "An error occurred inside the recognizer..."
![erreur](https://github.com/user-attachments/assets/36c6ac36-9b52-4cab-b46a-5102e5da28da)
